### PR TITLE
add permutation_method={"brutal-force", "lookup-table"} in lisa.R

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -85,48 +85,48 @@ p_LISA__GetFDR <- function(xp, pval) {
     .Call('_rgeoda_p_LISA__GetFDR', PACKAGE = 'rgeoda', xp, pval)
 }
 
-p_localmoran <- function(xp_w, data, permutations, significance_cutoff, cpu_threads, seed) {
-    .Call('_rgeoda_p_localmoran', PACKAGE = 'rgeoda', xp_w, data, permutations, significance_cutoff, cpu_threads, seed)
+p_localmoran <- function(xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed) {
+    .Call('_rgeoda_p_localmoran', PACKAGE = 'rgeoda', xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 }
 
 p_eb_rate <- function(event_data, base_data) {
     .Call('_rgeoda_p_eb_rate', PACKAGE = 'rgeoda', event_data, base_data)
 }
 
-p_localmoran_eb <- function(xp_w, event_data, base_data, permutations, significance_cutoff, cpu_threads, seed) {
-    .Call('_rgeoda_p_localmoran_eb', PACKAGE = 'rgeoda', xp_w, event_data, base_data, permutations, significance_cutoff, cpu_threads, seed)
+p_localmoran_eb <- function(xp_w, event_data, base_data, permutations, permutation_method, significance_cutoff, cpu_threads, seed) {
+    .Call('_rgeoda_p_localmoran_eb', PACKAGE = 'rgeoda', xp_w, event_data, base_data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 }
 
-p_localgeary <- function(xp_w, data, permutations, significance_cutoff, cpu_threads, seed) {
-    .Call('_rgeoda_p_localgeary', PACKAGE = 'rgeoda', xp_w, data, permutations, significance_cutoff, cpu_threads, seed)
+p_localgeary <- function(xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed) {
+    .Call('_rgeoda_p_localgeary', PACKAGE = 'rgeoda', xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 }
 
-p_localmultigeary <- function(xp_w, data, n_vars, permutations, significance_cutoff, cpu_threads, seed) {
-    .Call('_rgeoda_p_localmultigeary', PACKAGE = 'rgeoda', xp_w, data, n_vars, permutations, significance_cutoff, cpu_threads, seed)
+p_localmultigeary <- function(xp_w, data, n_vars, permutations, permutation_method, significance_cutoff, cpu_threads, seed) {
+    .Call('_rgeoda_p_localmultigeary', PACKAGE = 'rgeoda', xp_w, data, n_vars, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 }
 
-p_localg <- function(xp_w, data, permutations, significance_cutoff, cpu_threads, seed) {
-    .Call('_rgeoda_p_localg', PACKAGE = 'rgeoda', xp_w, data, permutations, significance_cutoff, cpu_threads, seed)
+p_localg <- function(xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed) {
+    .Call('_rgeoda_p_localg', PACKAGE = 'rgeoda', xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 }
 
-p_localgstar <- function(xp_w, data, permutations, significance_cutoff, cpu_threads, seed) {
-    .Call('_rgeoda_p_localgstar', PACKAGE = 'rgeoda', xp_w, data, permutations, significance_cutoff, cpu_threads, seed)
+p_localgstar <- function(xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed) {
+    .Call('_rgeoda_p_localgstar', PACKAGE = 'rgeoda', xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 }
 
-p_localjoincount <- function(xp_w, data, permutations, significance_cutoff, cpu_threads, seed) {
-    .Call('_rgeoda_p_localjoincount', PACKAGE = 'rgeoda', xp_w, data, permutations, significance_cutoff, cpu_threads, seed)
+p_localjoincount <- function(xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed) {
+    .Call('_rgeoda_p_localjoincount', PACKAGE = 'rgeoda', xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 }
 
-p_localmultijoincount <- function(xp_w, data, n_vars, permutations, significance_cutoff, cpu_threads, seed) {
-    .Call('_rgeoda_p_localmultijoincount', PACKAGE = 'rgeoda', xp_w, data, n_vars, permutations, significance_cutoff, cpu_threads, seed)
+p_localmultijoincount <- function(xp_w, data, n_vars, permutations, permutation_method, significance_cutoff, cpu_threads, seed) {
+    .Call('_rgeoda_p_localmultijoincount', PACKAGE = 'rgeoda', xp_w, data, n_vars, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 }
 
-p_quantilelisa <- function(xp_w, k, quantile, data, permutations, significance_cutoff, cpu_threads, seed) {
-    .Call('_rgeoda_p_quantilelisa', PACKAGE = 'rgeoda', xp_w, k, quantile, data, permutations, significance_cutoff, cpu_threads, seed)
+p_quantilelisa <- function(xp_w, k, quantile, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed) {
+    .Call('_rgeoda_p_quantilelisa', PACKAGE = 'rgeoda', xp_w, k, quantile, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 }
 
-p_multiquantilelisa <- function(xp_w, k_s, q_s, data_s, permutations, significance_cutoff, cpu_threads, seed) {
-    .Call('_rgeoda_p_multiquantilelisa', PACKAGE = 'rgeoda', xp_w, k_s, q_s, data_s, permutations, significance_cutoff, cpu_threads, seed)
+p_multiquantilelisa <- function(xp_w, k_s, q_s, data_s, permutations, permutation_method, significance_cutoff, cpu_threads, seed) {
+    .Call('_rgeoda_p_multiquantilelisa', PACKAGE = 'rgeoda', xp_w, k_s, q_s, data_s, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 }
 
 p_neighbor_match_test <- function(xp_geoda, k, power, is_inverse, is_arc, is_mile, data_s, n_vars, scale_method, dist_type) {

--- a/R/lisa.R
+++ b/R/lisa.R
@@ -291,7 +291,7 @@ lisa_colors <- function(gda_lisa) {
 #' lms <- lisa_values(lisa)
 #' lms
 #' @export
-local_moran <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_moran <- function(w, df, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (w$num_obs <= 0) {
     stop("Weights object is not valid.")
   }
@@ -301,7 +301,7 @@ local_moran <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_t
   }
 
   data <- df[[1]]
-  lisa_obj <- p_localmoran(w$GetPointer(), data, permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_localmoran(w$GetPointer(), data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
   return (LISA$new(p_LISA(lisa_obj)))
 }
 
@@ -325,7 +325,7 @@ local_moran <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_t
 #' lms
 #' }
 #' @export
-local_moran_eb <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_moran_eb <- function(w, df, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (class(w)[[1]] != "Weight") {
     stop("The parameter 'w' needs to be an instance of Weight object.")
   }
@@ -340,7 +340,7 @@ local_moran_eb <- function(w, df, permutations=999, significance_cutoff=0.05, cp
   event_data <- df[[1]]
   base_data <- df[[2]]
 
-  lisa_obj <- p_localmoran_eb(w$GetPointer(), event_data, base_data, permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_localmoran_eb(w$GetPointer(), event_data, base_data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
   return (LISA$new(p_LISA(lisa_obj)))
 }
 
@@ -363,7 +363,7 @@ local_moran_eb <- function(w, df, permutations=999, significance_cutoff=0.05, cp
 #' lms <- lisa_values(lisa)
 #' lms
 #' @export
-local_geary <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_geary <- function(w, df, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (w$num_obs <= 0) {
     stop("Weights object is not valid.")
   }
@@ -373,7 +373,7 @@ local_geary <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_t
   }
 
   data <- df[[1]]
-  lisa_obj <- p_localgeary(w$GetPointer(), data, permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_localgeary(w$GetPointer(), data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 
   return (LISA$new(p_LISA(lisa_obj)))
 }
@@ -398,7 +398,7 @@ local_geary <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_t
 #' lms <- lisa_clusters(lisa)
 #' lms
 #' @export
-local_multigeary <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_multigeary <- function(w, df, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (w$num_obs <= 0) {
     stop("Weights object is not valid.")
   }
@@ -413,7 +413,7 @@ local_multigeary <- function(w, df, permutations=999, significance_cutoff=0.05, 
     num_vars <- num_vars - 1
   }
 
-  lisa_obj <- p_localmultigeary(w$GetPointer(), df, num_vars, permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_localmultigeary(w$GetPointer(), df, num_vars, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
   return (LISA$new(p_LISA(lisa_obj)))
 }
 
@@ -436,7 +436,7 @@ local_multigeary <- function(w, df, permutations=999, significance_cutoff=0.05, 
 #' lms <- lisa_values(lisa)
 #' lms
 #' @export
-local_g <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_g <- function(w, df, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (w$num_obs <= 0) {
     stop("Weights object is not valid.")
   }
@@ -446,7 +446,7 @@ local_g <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threa
 
   data <- df[[1]]
 
-  lisa_obj <- p_localg(w$GetPointer(), data, permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_localg(w$GetPointer(), data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
   return (LISA$new(p_LISA(lisa_obj)))
 }
 
@@ -469,7 +469,7 @@ local_g <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threa
 #' lms <- lisa_values(lisa)
 #' lms
 #' @export
-local_gstar <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_gstar <- function(w, df, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (w$num_obs <= 0) {
     stop("Weights object is not valid.")
   }
@@ -479,7 +479,7 @@ local_gstar <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_t
 
   data <- df[[1]]
 
-  lisa_obj <- p_localgstar(w$GetPointer(), data, permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_localgstar(w$GetPointer(), data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
   return (LISA$new(p_LISA(lisa_obj)))
 }
 
@@ -502,7 +502,7 @@ local_gstar <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_t
 #' clsts<- lisa_clusters(lisa)
 #' clsts
 #' @export
-local_joincount <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_joincount <- function(w, df, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (w$num_obs <= 0) {
     stop("Weights object is not valid.")
   }
@@ -512,7 +512,7 @@ local_joincount <- function(w, df, permutations=999, significance_cutoff=0.05, c
 
   data <- df[[1]]
 
-  lisa_obj <- p_localjoincount(w$GetPointer(), data, permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_localjoincount(w$GetPointer(), data, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 
   jc <- LISA$new(p_LISA(lisa_obj))
 
@@ -546,7 +546,7 @@ local_joincount <- function(w, df, permutations=999, significance_cutoff=0.05, c
 #' clsts<- lisa_clusters(lisa)
 #' clsts
 #' @export
-local_bijoincount <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_bijoincount <- function(w, df, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (w$num_obs <= 0) {
     stop("Weights object is not valid.")
   }
@@ -565,7 +565,7 @@ local_bijoincount <- function(w, df, permutations=999, significance_cutoff=0.05,
     stop("The bivariate local join count only applies on two variables with no-colocation.")
   }
 
-  lisa_obj <- p_localmultijoincount(w$GetPointer(), df, 2, permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_localmultijoincount(w$GetPointer(), df, 2, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
   jc <- LISA$new(p_LISA(lisa_obj))
 
   # update the probability results: change these with jc=0 to NA
@@ -597,7 +597,7 @@ local_bijoincount <- function(w, df, permutations=999, significance_cutoff=0.05,
 #' clsts <- lisa_clusters(lisa)
 #' clsts
 #' @export
-local_multijoincount <- function(w, df, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_multijoincount <- function(w, df, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (w$num_obs <= 0) {
     stop("Weights object is not valid.")
   }
@@ -624,7 +624,7 @@ local_multijoincount <- function(w, df, permutations=999, significance_cutoff=0.
     }
   }
 
-  lisa_obj <- p_localmultijoincount(w$GetPointer(), df, num_vars, permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_localmultijoincount(w$GetPointer(), df, num_vars, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
   jc <- LISA$new(p_LISA(lisa_obj))
 
   # update the probability results: change these with jc=0 to NA
@@ -658,7 +658,7 @@ local_multijoincount <- function(w, df, permutations=999, significance_cutoff=0.
 #' clsts <- lisa_clusters(lisa)
 #' clsts
 #' @export
-local_quantilelisa <- function(w, df, k, q, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_quantilelisa <- function(w, df, k, q, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (w$num_obs <= 0) {
     stop("Weights object is not valid.")
   }
@@ -673,7 +673,7 @@ local_quantilelisa <- function(w, df, k, q, permutations=999, significance_cutof
     stop("The value of which quantile been selected should be in the range of [1, k]")
   }
 
-  lisa_obj <- p_quantilelisa(w$GetPointer(), k, q, df[[1]], permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_quantilelisa(w$GetPointer(), k, q, df[[1]], permutations, permutation_method, significance_cutoff, cpu_threads, seed)
 
   return (LISA$new(p_LISA(lisa_obj)))
 }
@@ -699,7 +699,7 @@ local_quantilelisa <- function(w, df, k, q, permutations=999, significance_cutof
 #' clsts <- lisa_clusters(lisa)
 #' clsts
 #' @export
-local_multiquantilelisa <- function(w, df, k, q, permutations=999, significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
+local_multiquantilelisa <- function(w, df, k, q, permutations=999, permutation_method="brutal-force", significance_cutoff=0.05, cpu_threads=6, seed=123456789) {
   if (w$num_obs <= 0) {
     stop("Weights object is not valid.")
   }
@@ -731,7 +731,7 @@ local_multiquantilelisa <- function(w, df, k, q, permutations=999, significance_
     }
   }
 
-  lisa_obj <- p_multiquantilelisa(w$GetPointer(), k, q, df, permutations, significance_cutoff, cpu_threads, seed)
+  lisa_obj <- p_multiquantilelisa(w$GetPointer(), k, q, df, permutations, permutation_method, significance_cutoff, cpu_threads, seed)
   return (LISA$new(p_LISA(lisa_obj)))
 }
 

--- a/man/LISA-class.Rd
+++ b/man/LISA-class.Rd
@@ -37,15 +37,13 @@ A LISA-class that wrappers the statistics of LISA computation
 
 \item{\code{GetFDR(current_p)}}{Get the False Discovery Rate value}
 
-\item{\code{GetLabels()}}{Get the cluster labels of LISA computation.}
-
 \item{\code{GetLISAValues()}}{Get the local spatial autocorrelation values returned from LISA computation.}
+
+\item{\code{GetLabels()}}{Get the cluster labels of LISA computation.}
 
 \item{\code{GetLocalSignificanceValues()}}{Get the local pseudo-p values of significance returned from LISA computation.}
 
 \item{\code{GetNumNeighbors()}}{Get the number of neighbors of every observations in LISA computation.}
-
-\item{\code{initialize(lisa_obj)}}{Constructor with a LISA object (internally used)}
 
 \item{\code{Run()}}{Call to run LISA computation}
 
@@ -54,5 +52,7 @@ A LISA-class that wrappers the statistics of LISA computation
 \item{\code{SetSignificanceCutoff(cutoff)}}{Set the cutoff value of significance values}
 
 \item{\code{SetThreads(num_threads)}}{Set the number of CPU threads for the LISA computation}
+
+\item{\code{initialize(lisa_obj)}}{Constructor with a LISA object (internally used)}
 }}
 

--- a/man/Weight-class.Rd
+++ b/man/Weight-class.Rd
@@ -33,17 +33,15 @@ A wrapper class for p_GeoDaWeight class
 \section{Methods}{
 
 \describe{
-\item{\code{GetNeighbors(idx)}}{Get neighbors for idx-th observation, idx starts from 0}
-
 \item{\code{GetNeighborWeights(idx)}}{Get weights values of neighbors for idx-th observation, idx starts from 0}
+
+\item{\code{GetNeighbors(idx)}}{Get neighbors for idx-th observation, idx starts from 0}
 
 \item{\code{GetPointer()}}{Get the C++ object pointer (internally used)}
 
 \item{\code{GetSparsity()}}{Get sparsity computed from weights matrix}
 
 \item{\code{HasIsolates()}}{Check if weights matrix has isolates, or if any observation has no neighbors}
-
-\item{\code{initialize(o_gda_w)}}{Constructor with a GeoDaWeight object (internally used)}
 
 \item{\code{IsSymmetric()}}{Check if weights matrix is symmetric}
 
@@ -54,5 +52,7 @@ id_name : The id name (or field name), which is an associated column contains un
 id_values : The tuple of values of selected id_name (column/field)}
 
 \item{\code{SpatialLag(values)}}{Compute spatial lag values for values of selected variable}
+
+\item{\code{initialize(o_gda_w)}}{Constructor with a GeoDaWeight object (internally used)}
 }}
 

--- a/man/local_bijoincount.Rd
+++ b/man/local_bijoincount.Rd
@@ -8,6 +8,7 @@ local_bijoincount(
   w,
   df,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/man/local_g.Rd
+++ b/man/local_g.Rd
@@ -8,6 +8,7 @@ local_g(
   w,
   df,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/man/local_geary.Rd
+++ b/man/local_geary.Rd
@@ -8,6 +8,7 @@ local_geary(
   w,
   df,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/man/local_gstar.Rd
+++ b/man/local_gstar.Rd
@@ -8,6 +8,7 @@ local_gstar(
   w,
   df,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/man/local_joincount.Rd
+++ b/man/local_joincount.Rd
@@ -8,6 +8,7 @@ local_joincount(
   w,
   df,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/man/local_moran.Rd
+++ b/man/local_moran.Rd
@@ -8,6 +8,7 @@ local_moran(
   w,
   df,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/man/local_moran_eb.Rd
+++ b/man/local_moran_eb.Rd
@@ -8,6 +8,7 @@ local_moran_eb(
   w,
   df,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/man/local_multigeary.Rd
+++ b/man/local_multigeary.Rd
@@ -8,6 +8,7 @@ local_multigeary(
   w,
   df,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/man/local_multijoincount.Rd
+++ b/man/local_multijoincount.Rd
@@ -8,6 +8,7 @@ local_multijoincount(
   w,
   df,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/man/local_multiquantilelisa.Rd
+++ b/man/local_multiquantilelisa.Rd
@@ -10,6 +10,7 @@ local_multiquantilelisa(
   k,
   q,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/man/local_quantilelisa.Rd
+++ b/man/local_quantilelisa.Rd
@@ -10,6 +10,7 @@ local_quantilelisa(
   k,
   q,
   permutations = 999,
+  permutation_method = "brutal-force",
   significance_cutoff = 0.05,
   cpu_threads = 6,
   seed = 123456789

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -333,18 +333,19 @@ BEGIN_RCPP
 END_RCPP
 }
 // p_localmoran
-SEXP p_localmoran(SEXP xp_w, NumericVector data, int permutations, double significance_cutoff, int cpu_threads, int seed);
-RcppExport SEXP _rgeoda_p_localmoran(SEXP xp_wSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
+SEXP p_localmoran(SEXP xp_w, NumericVector data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed);
+RcppExport SEXP _rgeoda_p_localmoran(SEXP xp_wSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP permutation_methodSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type xp_w(xp_wSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type data(dataSEXP);
     Rcpp::traits::input_parameter< int >::type permutations(permutationsSEXP);
+    Rcpp::traits::input_parameter< std::string >::type permutation_method(permutation_methodSEXP);
     Rcpp::traits::input_parameter< double >::type significance_cutoff(significance_cutoffSEXP);
     Rcpp::traits::input_parameter< int >::type cpu_threads(cpu_threadsSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(p_localmoran(xp_w, data, permutations, significance_cutoff, cpu_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(p_localmoran(xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -361,8 +362,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // p_localmoran_eb
-SEXP p_localmoran_eb(SEXP xp_w, NumericVector& event_data, NumericVector& base_data, int permutations, double significance_cutoff, int cpu_threads, int seed);
-RcppExport SEXP _rgeoda_p_localmoran_eb(SEXP xp_wSEXP, SEXP event_dataSEXP, SEXP base_dataSEXP, SEXP permutationsSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
+SEXP p_localmoran_eb(SEXP xp_w, NumericVector& event_data, NumericVector& base_data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed);
+RcppExport SEXP _rgeoda_p_localmoran_eb(SEXP xp_wSEXP, SEXP event_dataSEXP, SEXP base_dataSEXP, SEXP permutationsSEXP, SEXP permutation_methodSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -370,32 +371,34 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericVector& >::type event_data(event_dataSEXP);
     Rcpp::traits::input_parameter< NumericVector& >::type base_data(base_dataSEXP);
     Rcpp::traits::input_parameter< int >::type permutations(permutationsSEXP);
+    Rcpp::traits::input_parameter< std::string >::type permutation_method(permutation_methodSEXP);
     Rcpp::traits::input_parameter< double >::type significance_cutoff(significance_cutoffSEXP);
     Rcpp::traits::input_parameter< int >::type cpu_threads(cpu_threadsSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(p_localmoran_eb(xp_w, event_data, base_data, permutations, significance_cutoff, cpu_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(p_localmoran_eb(xp_w, event_data, base_data, permutations, permutation_method, significance_cutoff, cpu_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // p_localgeary
-SEXP p_localgeary(SEXP xp_w, NumericVector& data, int permutations, double significance_cutoff, int cpu_threads, int seed);
-RcppExport SEXP _rgeoda_p_localgeary(SEXP xp_wSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
+SEXP p_localgeary(SEXP xp_w, NumericVector& data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed);
+RcppExport SEXP _rgeoda_p_localgeary(SEXP xp_wSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP permutation_methodSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type xp_w(xp_wSEXP);
     Rcpp::traits::input_parameter< NumericVector& >::type data(dataSEXP);
     Rcpp::traits::input_parameter< int >::type permutations(permutationsSEXP);
+    Rcpp::traits::input_parameter< std::string >::type permutation_method(permutation_methodSEXP);
     Rcpp::traits::input_parameter< double >::type significance_cutoff(significance_cutoffSEXP);
     Rcpp::traits::input_parameter< int >::type cpu_threads(cpu_threadsSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(p_localgeary(xp_w, data, permutations, significance_cutoff, cpu_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(p_localgeary(xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // p_localmultigeary
-SEXP p_localmultigeary(SEXP xp_w, Rcpp::List& data, int n_vars, int permutations, double significance_cutoff, int cpu_threads, int seed);
-RcppExport SEXP _rgeoda_p_localmultigeary(SEXP xp_wSEXP, SEXP dataSEXP, SEXP n_varsSEXP, SEXP permutationsSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
+SEXP p_localmultigeary(SEXP xp_w, Rcpp::List& data, int n_vars, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed);
+RcppExport SEXP _rgeoda_p_localmultigeary(SEXP xp_wSEXP, SEXP dataSEXP, SEXP n_varsSEXP, SEXP permutationsSEXP, SEXP permutation_methodSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -403,64 +406,68 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::List& >::type data(dataSEXP);
     Rcpp::traits::input_parameter< int >::type n_vars(n_varsSEXP);
     Rcpp::traits::input_parameter< int >::type permutations(permutationsSEXP);
+    Rcpp::traits::input_parameter< std::string >::type permutation_method(permutation_methodSEXP);
     Rcpp::traits::input_parameter< double >::type significance_cutoff(significance_cutoffSEXP);
     Rcpp::traits::input_parameter< int >::type cpu_threads(cpu_threadsSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(p_localmultigeary(xp_w, data, n_vars, permutations, significance_cutoff, cpu_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(p_localmultigeary(xp_w, data, n_vars, permutations, permutation_method, significance_cutoff, cpu_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // p_localg
-SEXP p_localg(SEXP xp_w, NumericVector& data, int permutations, double significance_cutoff, int cpu_threads, int seed);
-RcppExport SEXP _rgeoda_p_localg(SEXP xp_wSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
+SEXP p_localg(SEXP xp_w, NumericVector& data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed);
+RcppExport SEXP _rgeoda_p_localg(SEXP xp_wSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP permutation_methodSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type xp_w(xp_wSEXP);
     Rcpp::traits::input_parameter< NumericVector& >::type data(dataSEXP);
     Rcpp::traits::input_parameter< int >::type permutations(permutationsSEXP);
+    Rcpp::traits::input_parameter< std::string >::type permutation_method(permutation_methodSEXP);
     Rcpp::traits::input_parameter< double >::type significance_cutoff(significance_cutoffSEXP);
     Rcpp::traits::input_parameter< int >::type cpu_threads(cpu_threadsSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(p_localg(xp_w, data, permutations, significance_cutoff, cpu_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(p_localg(xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // p_localgstar
-SEXP p_localgstar(SEXP xp_w, NumericVector& data, int permutations, double significance_cutoff, int cpu_threads, int seed);
-RcppExport SEXP _rgeoda_p_localgstar(SEXP xp_wSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
+SEXP p_localgstar(SEXP xp_w, NumericVector& data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed);
+RcppExport SEXP _rgeoda_p_localgstar(SEXP xp_wSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP permutation_methodSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type xp_w(xp_wSEXP);
     Rcpp::traits::input_parameter< NumericVector& >::type data(dataSEXP);
     Rcpp::traits::input_parameter< int >::type permutations(permutationsSEXP);
+    Rcpp::traits::input_parameter< std::string >::type permutation_method(permutation_methodSEXP);
     Rcpp::traits::input_parameter< double >::type significance_cutoff(significance_cutoffSEXP);
     Rcpp::traits::input_parameter< int >::type cpu_threads(cpu_threadsSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(p_localgstar(xp_w, data, permutations, significance_cutoff, cpu_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(p_localgstar(xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // p_localjoincount
-SEXP p_localjoincount(SEXP xp_w, NumericVector& data, int permutations, double significance_cutoff, int cpu_threads, int seed);
-RcppExport SEXP _rgeoda_p_localjoincount(SEXP xp_wSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
+SEXP p_localjoincount(SEXP xp_w, NumericVector& data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed);
+RcppExport SEXP _rgeoda_p_localjoincount(SEXP xp_wSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP permutation_methodSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type xp_w(xp_wSEXP);
     Rcpp::traits::input_parameter< NumericVector& >::type data(dataSEXP);
     Rcpp::traits::input_parameter< int >::type permutations(permutationsSEXP);
+    Rcpp::traits::input_parameter< std::string >::type permutation_method(permutation_methodSEXP);
     Rcpp::traits::input_parameter< double >::type significance_cutoff(significance_cutoffSEXP);
     Rcpp::traits::input_parameter< int >::type cpu_threads(cpu_threadsSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(p_localjoincount(xp_w, data, permutations, significance_cutoff, cpu_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(p_localjoincount(xp_w, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // p_localmultijoincount
-SEXP p_localmultijoincount(SEXP xp_w, Rcpp::List& data, int n_vars, int permutations, double significance_cutoff, int cpu_threads, int seed);
-RcppExport SEXP _rgeoda_p_localmultijoincount(SEXP xp_wSEXP, SEXP dataSEXP, SEXP n_varsSEXP, SEXP permutationsSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
+SEXP p_localmultijoincount(SEXP xp_w, Rcpp::List& data, int n_vars, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed);
+RcppExport SEXP _rgeoda_p_localmultijoincount(SEXP xp_wSEXP, SEXP dataSEXP, SEXP n_varsSEXP, SEXP permutationsSEXP, SEXP permutation_methodSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -468,16 +475,17 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::List& >::type data(dataSEXP);
     Rcpp::traits::input_parameter< int >::type n_vars(n_varsSEXP);
     Rcpp::traits::input_parameter< int >::type permutations(permutationsSEXP);
+    Rcpp::traits::input_parameter< std::string >::type permutation_method(permutation_methodSEXP);
     Rcpp::traits::input_parameter< double >::type significance_cutoff(significance_cutoffSEXP);
     Rcpp::traits::input_parameter< int >::type cpu_threads(cpu_threadsSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(p_localmultijoincount(xp_w, data, n_vars, permutations, significance_cutoff, cpu_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(p_localmultijoincount(xp_w, data, n_vars, permutations, permutation_method, significance_cutoff, cpu_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // p_quantilelisa
-SEXP p_quantilelisa(SEXP xp_w, int k, int quantile, NumericVector& data, int permutations, double significance_cutoff, int cpu_threads, int seed);
-RcppExport SEXP _rgeoda_p_quantilelisa(SEXP xp_wSEXP, SEXP kSEXP, SEXP quantileSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
+SEXP p_quantilelisa(SEXP xp_w, int k, int quantile, NumericVector& data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed);
+RcppExport SEXP _rgeoda_p_quantilelisa(SEXP xp_wSEXP, SEXP kSEXP, SEXP quantileSEXP, SEXP dataSEXP, SEXP permutationsSEXP, SEXP permutation_methodSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -486,16 +494,17 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type quantile(quantileSEXP);
     Rcpp::traits::input_parameter< NumericVector& >::type data(dataSEXP);
     Rcpp::traits::input_parameter< int >::type permutations(permutationsSEXP);
+    Rcpp::traits::input_parameter< std::string >::type permutation_method(permutation_methodSEXP);
     Rcpp::traits::input_parameter< double >::type significance_cutoff(significance_cutoffSEXP);
     Rcpp::traits::input_parameter< int >::type cpu_threads(cpu_threadsSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(p_quantilelisa(xp_w, k, quantile, data, permutations, significance_cutoff, cpu_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(p_quantilelisa(xp_w, k, quantile, data, permutations, permutation_method, significance_cutoff, cpu_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // p_multiquantilelisa
-SEXP p_multiquantilelisa(SEXP xp_w, NumericVector& k_s, NumericVector& q_s, Rcpp::List& data_s, int permutations, double significance_cutoff, int cpu_threads, int seed);
-RcppExport SEXP _rgeoda_p_multiquantilelisa(SEXP xp_wSEXP, SEXP k_sSEXP, SEXP q_sSEXP, SEXP data_sSEXP, SEXP permutationsSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
+SEXP p_multiquantilelisa(SEXP xp_w, NumericVector& k_s, NumericVector& q_s, Rcpp::List& data_s, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed);
+RcppExport SEXP _rgeoda_p_multiquantilelisa(SEXP xp_wSEXP, SEXP k_sSEXP, SEXP q_sSEXP, SEXP data_sSEXP, SEXP permutationsSEXP, SEXP permutation_methodSEXP, SEXP significance_cutoffSEXP, SEXP cpu_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -504,10 +513,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericVector& >::type q_s(q_sSEXP);
     Rcpp::traits::input_parameter< Rcpp::List& >::type data_s(data_sSEXP);
     Rcpp::traits::input_parameter< int >::type permutations(permutationsSEXP);
+    Rcpp::traits::input_parameter< std::string >::type permutation_method(permutation_methodSEXP);
     Rcpp::traits::input_parameter< double >::type significance_cutoff(significance_cutoffSEXP);
     Rcpp::traits::input_parameter< int >::type cpu_threads(cpu_threadsSEXP);
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(p_multiquantilelisa(xp_w, k_s, q_s, data_s, permutations, significance_cutoff, cpu_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(p_multiquantilelisa(xp_w, k_s, q_s, data_s, permutations, permutation_method, significance_cutoff, cpu_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1104,17 +1114,17 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rgeoda_p_LISA__GetColors", (DL_FUNC) &_rgeoda_p_LISA__GetColors, 1},
     {"_rgeoda_p_LISA__GetBO", (DL_FUNC) &_rgeoda_p_LISA__GetBO, 2},
     {"_rgeoda_p_LISA__GetFDR", (DL_FUNC) &_rgeoda_p_LISA__GetFDR, 2},
-    {"_rgeoda_p_localmoran", (DL_FUNC) &_rgeoda_p_localmoran, 6},
+    {"_rgeoda_p_localmoran", (DL_FUNC) &_rgeoda_p_localmoran, 7},
     {"_rgeoda_p_eb_rate", (DL_FUNC) &_rgeoda_p_eb_rate, 2},
-    {"_rgeoda_p_localmoran_eb", (DL_FUNC) &_rgeoda_p_localmoran_eb, 7},
-    {"_rgeoda_p_localgeary", (DL_FUNC) &_rgeoda_p_localgeary, 6},
-    {"_rgeoda_p_localmultigeary", (DL_FUNC) &_rgeoda_p_localmultigeary, 7},
-    {"_rgeoda_p_localg", (DL_FUNC) &_rgeoda_p_localg, 6},
-    {"_rgeoda_p_localgstar", (DL_FUNC) &_rgeoda_p_localgstar, 6},
-    {"_rgeoda_p_localjoincount", (DL_FUNC) &_rgeoda_p_localjoincount, 6},
-    {"_rgeoda_p_localmultijoincount", (DL_FUNC) &_rgeoda_p_localmultijoincount, 7},
-    {"_rgeoda_p_quantilelisa", (DL_FUNC) &_rgeoda_p_quantilelisa, 8},
-    {"_rgeoda_p_multiquantilelisa", (DL_FUNC) &_rgeoda_p_multiquantilelisa, 8},
+    {"_rgeoda_p_localmoran_eb", (DL_FUNC) &_rgeoda_p_localmoran_eb, 8},
+    {"_rgeoda_p_localgeary", (DL_FUNC) &_rgeoda_p_localgeary, 7},
+    {"_rgeoda_p_localmultigeary", (DL_FUNC) &_rgeoda_p_localmultigeary, 8},
+    {"_rgeoda_p_localg", (DL_FUNC) &_rgeoda_p_localg, 7},
+    {"_rgeoda_p_localgstar", (DL_FUNC) &_rgeoda_p_localgstar, 7},
+    {"_rgeoda_p_localjoincount", (DL_FUNC) &_rgeoda_p_localjoincount, 7},
+    {"_rgeoda_p_localmultijoincount", (DL_FUNC) &_rgeoda_p_localmultijoincount, 8},
+    {"_rgeoda_p_quantilelisa", (DL_FUNC) &_rgeoda_p_quantilelisa, 9},
+    {"_rgeoda_p_multiquantilelisa", (DL_FUNC) &_rgeoda_p_multiquantilelisa, 9},
     {"_rgeoda_p_neighbor_match_test", (DL_FUNC) &_rgeoda_p_neighbor_match_test, 10},
     {"_rgeoda_p_GeoDa__new", (DL_FUNC) &_rgeoda_p_GeoDa__new, 1},
     {"_rgeoda_p_GeoDa__new1", (DL_FUNC) &_rgeoda_p_GeoDa__new1, 6},

--- a/src/libgeoda_src/gda_sa.cpp
+++ b/src/libgeoda_src/gda_sa.cpp
@@ -22,7 +22,8 @@
 LISA *gda_localg(GeoDaWeight *w,
                  const std::vector<double> &data,
                  const std::vector<bool> &undefs,
-                 double significance_cutoff, int nCPUs, int perm, int last_seed)
+                 double significance_cutoff, int nCPUs, int perm,
+                 const std::string& perm_method, int last_seed)
 {
     if (w == 0)
         return 0;
@@ -34,14 +35,14 @@ LISA *gda_localg(GeoDaWeight *w,
     {
         copy_undefs.resize(num_obs, false);
     }
-    UniG *localg = new UniG(num_obs, w, data, copy_undefs, significance_cutoff, nCPUs, perm, last_seed);
+    UniG *localg = new UniG(num_obs, w, data, copy_undefs, significance_cutoff, nCPUs, perm, perm_method, last_seed);
     return localg;
 }
 
 LISA *gda_localgstar(GeoDaWeight *w,
                      const std::vector<double> &data,
                      const std::vector<bool> &undefs,
-                     double significance_cutoff, int nCPUs, int perm, int last_seed)
+                     double significance_cutoff, int nCPUs, int perm, const std::string& perm_method,  int last_seed)
 {
     if (w == 0)
         return 0;
@@ -53,14 +54,14 @@ LISA *gda_localgstar(GeoDaWeight *w,
     {
         copy_undefs.resize(num_obs, false);
     }
-    UniGstar *localgstar = new UniGstar(num_obs, w, data, copy_undefs, significance_cutoff, nCPUs, perm, last_seed);
+    UniGstar *localgstar = new UniGstar(num_obs, w, data, copy_undefs, significance_cutoff, nCPUs, perm, perm_method, last_seed);
     return localgstar;
 }
 
 LISA *gda_localmoran(GeoDaWeight *w,
                      const std::vector<double> &data,
                      const std::vector<bool> &undefs,
-                     double significance_cutoff, int nCPUs, int perm, int last_seed)
+                     double significance_cutoff, int nCPUs, int perm, const std::string& perm_method,  int last_seed)
 {
     if (w == 0)
         return 0;
@@ -72,7 +73,7 @@ LISA *gda_localmoran(GeoDaWeight *w,
     {
         copy_undefs.resize(num_obs, false);
     }
-    UniLocalMoran *lisa = new UniLocalMoran(num_obs, w, data, copy_undefs, significance_cutoff, nCPUs, perm, last_seed);
+    UniLocalMoran *lisa = new UniLocalMoran(num_obs, w, data, copy_undefs, significance_cutoff, nCPUs, perm, perm_method, last_seed);
     return lisa;
 }
 
@@ -80,7 +81,7 @@ LISA *gda_localmoran_eb(GeoDaWeight *w,
                         const std::vector<double> &event_data,
                         const std::vector<double> &base_data,
                         double significance_cutoff,
-                        int nCPUs, int permutations, int last_seed_used)
+                        int nCPUs, int permutations, const std::string& perm_method, int last_seed_used)
 {
     if (w == 0)
         return 0;
@@ -98,14 +99,14 @@ LISA *gda_localmoran_eb(GeoDaWeight *w,
     if (success == false)
         return 0;
 
-    UniLocalMoran *lisa = new UniLocalMoran(num_obs, w, local_smoothed_results, undef_res, significance_cutoff, nCPUs, permutations, last_seed_used);
+    UniLocalMoran *lisa = new UniLocalMoran(num_obs, w, local_smoothed_results, undef_res, significance_cutoff, nCPUs, permutations, perm_method, last_seed_used);
     return lisa;
 }
 
 BatchLISA *gda_batchlocalmoran(GeoDaWeight *w,
                                const std::vector<std::vector<double> > &data,
                                const std::vector<std::vector<bool> > &undefs,
-                               double significance_cutoff, int nCPUs, int perm, int last_seed)
+                               double significance_cutoff, int nCPUs, int perm, const std::string& perm_method,  int last_seed)
 {
     if (w == 0)
         return 0;
@@ -127,7 +128,7 @@ BatchLISA *gda_batchlocalmoran(GeoDaWeight *w,
 LISA *gda_localgeary(GeoDaWeight *w,
                      const std::vector<double> &data,
                      const std::vector<bool> &undefs,
-                     double significance_cutoff, int nCPUs, int perm, int last_seed)
+                     double significance_cutoff, int nCPUs, int perm, const std::string& perm_method,  int last_seed)
 {
     if (w == 0)
         return 0;
@@ -139,28 +140,28 @@ LISA *gda_localgeary(GeoDaWeight *w,
     {
         copy_undefs.resize(num_obs, false);
     }
-    UniGeary *geary = new UniGeary(num_obs, w, data, copy_undefs, significance_cutoff, nCPUs, perm, last_seed);
+    UniGeary *geary = new UniGeary(num_obs, w, data, copy_undefs, significance_cutoff, nCPUs, perm, perm_method, last_seed);
     return geary;
 }
 
 LISA *gda_localmultigeary(GeoDaWeight *w,
                      const std::vector<std::vector<double> > &data,
                      const std::vector<std::vector<bool> > &undefs,
-                     double significance_cutoff, int nCPUs, int perm, int last_seed)
+                     double significance_cutoff, int nCPUs, int perm, const std::string& perm_method,  int last_seed)
 {
     if (w == 0)
         return 0;
 
     int num_obs = w->num_obs;
 
-    MultiGeary *geary = new MultiGeary(num_obs, w, data, undefs, significance_cutoff, nCPUs, perm, last_seed);
+    MultiGeary *geary = new MultiGeary(num_obs, w, data, undefs, significance_cutoff, nCPUs, perm, perm_method, last_seed);
     return geary;
 }
 
 LISA *gda_localjoincount(GeoDaWeight *w,
                     const std::vector<double> &data,
                     const std::vector<bool> &undefs,
-                    double significance_cutoff, int nCPUs, int perm, int last_seed)
+                    double significance_cutoff, int nCPUs, int perm, const std::string& perm_method,  int last_seed)
 {
     if (w == 0)
         return 0;
@@ -172,21 +173,21 @@ LISA *gda_localjoincount(GeoDaWeight *w,
     {
         copy_undefs.resize(num_obs, false);
     }
-    UniJoinCount *jc = new UniJoinCount(num_obs, w, data, copy_undefs, significance_cutoff, nCPUs, perm, last_seed);
+    UniJoinCount *jc = new UniJoinCount(num_obs, w, data, copy_undefs, significance_cutoff, nCPUs, perm, perm_method, last_seed);
     return jc;
 }
 
 LISA *gda_localmultijoincount(GeoDaWeight *w,
                          const std::vector<std::vector<double> > &data,
                          const std::vector<std::vector<bool> > &undefs,
-                         double significance_cutoff, int nCPUs, int perm, int last_seed)
+                         double significance_cutoff, int nCPUs, int perm, const std::string& perm_method,  int last_seed)
 {
     if (w == 0)
         return 0;
 
     int num_obs = w->num_obs;
 
-    MultiJoinCount *jc = new MultiJoinCount(num_obs, w, data, undefs, significance_cutoff, nCPUs, perm, last_seed);
+    MultiJoinCount *jc = new MultiJoinCount(num_obs, w, data, undefs, significance_cutoff, nCPUs, perm, perm_method, last_seed);
     return jc;
 }
 
@@ -208,7 +209,7 @@ double gda_bo(LISA *lisa, double current_p)
 
 LISA *gda_quantilelisa(GeoDaWeight *w, unsigned int k, unsigned int quantile, const std::vector<double> &data,
                        const std::vector<bool> &undefs,
-                       double significance_cutoff, int nCPUs, int perm, int last_seed)
+                       double significance_cutoff, int nCPUs, int perm, const std::string& perm_method,  int last_seed)
 {
     if (w == 0)
         return 0;
@@ -258,13 +259,13 @@ LISA *gda_quantilelisa(GeoDaWeight *w, unsigned int k, unsigned int quantile, co
     }
 
     // apply local join count on binary data
-    UniJoinCount *jc = new UniJoinCount(num_obs, w, bin_data, copy_undefs, significance_cutoff, nCPUs, perm, last_seed);
+    UniJoinCount *jc = new UniJoinCount(num_obs, w, bin_data, copy_undefs, significance_cutoff, nCPUs, perm, perm_method, last_seed);
     return jc;
 }
 
 LISA *gda_multiquantilelisa(GeoDaWeight *w, const std::vector<int>& k_s, const std::vector<int>& quantile_s, const std::vector<std::vector<double> > &data_s,
                        const std::vector<std::vector<bool> > &undefs_s, double significance_cutoff,
-                       int nCPUs, int permutations, int last_seed_used)
+                       int nCPUs, int permutations, const std::string& perm_method, int last_seed_used)
 {
     if (w == 0)
         return 0;
@@ -325,7 +326,7 @@ LISA *gda_multiquantilelisa(GeoDaWeight *w, const std::vector<int>& k_s, const s
         data.push_back(bin_data);
     }
 
-    MultiJoinCount *jc = new MultiJoinCount(num_obs, w, data, undefs, significance_cutoff, nCPUs, permutations, last_seed_used);
+    MultiJoinCount *jc = new MultiJoinCount(num_obs, w, data, undefs, significance_cutoff, nCPUs, permutations, perm_method, last_seed_used);
     return jc;
 }
 

--- a/src/libgeoda_src/gda_sa.h
+++ b/src/libgeoda_src/gda_sa.h
@@ -20,7 +20,7 @@ class AbstractGeoDa;
 LISA *gda_localmoran(GeoDaWeight *w,
                      const std::vector<double> &data,
                      const std::vector<bool> &undefs, double significance_cutoff,
-                     int nCPUs, int permutations, int last_seed_used);
+                     int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 
 /**
  *
@@ -37,7 +37,7 @@ LISA *gda_localmoran_eb(GeoDaWeight *w,
                         const std::vector<double> &event_data,
                         const std::vector<double> &base_data,
                         double significance_cutoff,
-                        int nCPUs, int permutations, int last_seed_used);
+                        int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 /**
  *
  * @param w
@@ -47,7 +47,7 @@ LISA *gda_localmoran_eb(GeoDaWeight *w,
  */
 BatchLISA *gda_batchlocalmoran(GeoDaWeight *w, const std::vector<std::vector<double> > &data,
                                const std::vector<std::vector<bool> > &undefs, double significance_cutoff,
-                               int nCPUs, int permutations, int last_seed_used);
+                               int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 
 /**
  *
@@ -58,7 +58,7 @@ BatchLISA *gda_batchlocalmoran(GeoDaWeight *w, const std::vector<std::vector<dou
  */
 LISA *gda_localgeary(GeoDaWeight *w, const std::vector<double> &data,
                      const std::vector<bool> &undefs, double significance_cutoff,
-                     int nCPUs, int permutations, int last_seed_used);
+                     int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 
 /**
  *
@@ -69,7 +69,7 @@ LISA *gda_localgeary(GeoDaWeight *w, const std::vector<double> &data,
  */
 LISA *gda_localmultigeary(GeoDaWeight *w, const std::vector<std::vector<double> > &data,
                      const std::vector<std::vector<bool> > &undefs, double significance_cutoff,
-                     int nCPUs, int permutations, int last_seed_used);
+                     int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 
 /**
  *
@@ -80,11 +80,11 @@ LISA *gda_localmultigeary(GeoDaWeight *w, const std::vector<std::vector<double> 
  */
 LISA *gda_localjoincount(GeoDaWeight *w, const std::vector<double> &data,
                     const std::vector<bool> &undefs, double significance_cutoff,
-                    int nCPUs, int permutations, int last_seed_used);
+                    int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 
 LISA *gda_localmultijoincount(GeoDaWeight *w, const std::vector<std::vector<double> > &data,
                          const std::vector<std::vector<bool> > &undefs, double significance_cutoff,
-                         int nCPUs, int permutations, int last_seed_used);
+                         int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 /**
  *
  * @param w
@@ -94,7 +94,7 @@ LISA *gda_localmultijoincount(GeoDaWeight *w, const std::vector<std::vector<doub
  */
 LISA *gda_localg(GeoDaWeight *w, const std::vector<double> &data,
                  const std::vector<bool> &undefs, double significance_cutoff,
-                 int nCPUs, int permutations, int last_seed_used);
+                 int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 
 /**
  *
@@ -105,7 +105,7 @@ LISA *gda_localg(GeoDaWeight *w, const std::vector<double> &data,
  */
 LISA *gda_localgstar(GeoDaWeight *w, const std::vector<double> &data,
                      const std::vector<bool> &undefs, double significance_cutoff,
-                     int nCPUs, int permutations, int last_seed_used);
+                     int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 
 /**
  *
@@ -117,7 +117,7 @@ LISA *gda_localgstar(GeoDaWeight *w, const std::vector<double> &data,
  */
 LISA *gda_quantilelisa(GeoDaWeight *w, unsigned int k, unsigned int quantile, const std::vector<double> &data,
                        const std::vector<bool> &undefs, double significance_cutoff,
-                       int nCPUs, int permutations, int last_seed_used);
+                       int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 
 /**
  *
@@ -130,7 +130,7 @@ LISA *gda_quantilelisa(GeoDaWeight *w, unsigned int k, unsigned int quantile, co
  */
 LISA *gda_multiquantilelisa(GeoDaWeight *w, const std::vector<int>& k_s, const std::vector<int>& quantile_s, const std::vector<std::vector<double> > &data_s,
                        const std::vector<std::vector<bool> > &undefs_s, double significance_cutoff,
-                       int nCPUs, int permutations, int last_seed_used);
+                       int nCPUs, int permutations, const std::string& permutation_method, int last_seed_used);
 /**
  *
  * @param lisa

--- a/src/libgeoda_src/sa/LISA.h
+++ b/src/libgeoda_src/sa/LISA.h
@@ -23,12 +23,13 @@ public:
             double significance_cutoff,
             int nCPUs,
             int permutations,
+            const std::string& _permutation_method,
             uint64_t last_seed_used);
 
     LISA(int num_obs, GeoDaWeight* w, const std::vector<std::vector<bool> >& undefs,
          double significance_cutoff,
          int nCPUs,
-         int permutations,
+         int permutations, const std::string& _permutation_method,
          uint64_t last_seed_used);
 
     virtual ~LISA();
@@ -40,6 +41,13 @@ public:
     virtual void CalcPseudoP_threaded();
 
     virtual void CalcPseudoP_range(int obs_start, int obs_end, uint64_t seed_start);
+
+    // used for perm_method=="LookupTable"
+    virtual void PermCreateTable_threaded();
+    virtual void PermCreateRange(int perm_start, int perm_end, int max_neighbor, uint64_t seed_start);
+    virtual void PermCalcPseudoP_threaded();
+    virtual void PermCalcPseudoP_range(int obs_start, int obs_end, uint64_t seed_start);
+    virtual void PermLocalSA(int cnt, int perm, int numNeighbors, const int* permNeighbors, std::vector<double>& permutedSA) = 0;
 
     // compare local SA value of current obs to local SA values of random picked nbrs
     virtual void PermLocalSA(int cnt, int perm,
@@ -132,6 +140,9 @@ protected:
     std::vector<int> nn_vec;
     std::vector<std::string> labels;
     std::vector<std::string> colors;
+
+    int** perm_table;
+    std::string permutation_method;
 
 #ifdef __JSGEODA__
     // for caching in wasgeoda

--- a/src/libgeoda_src/sa/MultiGeary.cpp
+++ b/src/libgeoda_src/sa/MultiGeary.cpp
@@ -9,8 +9,8 @@
 MultiGeary::MultiGeary(int num_obs, GeoDaWeight *w,
         const std::vector<std::vector<double> > &_data,
         const std::vector<std::vector<bool> > &_undefs,
-        double significance_cutoff, int _nCPUs, int _perm, uint64_t _last_seed)
-: LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _last_seed),
+        double significance_cutoff, int _nCPUs, int _perm,  const std::string& _permutation_method, uint64_t _last_seed)
+: LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _permutation_method, _last_seed),
  CLUSTER_NOT_SIG(0),
  CLUSTER_POSITIVE(1),
  CLUSTER_NEGATIVE(2),

--- a/src/libgeoda_src/sa/MultiGeary.h
+++ b/src/libgeoda_src/sa/MultiGeary.h
@@ -21,13 +21,17 @@ public:
                const std::vector<std::vector<double> >& data,
                const std::vector<std::vector<bool> >& undefs,
                double significance_cutoff,
-               int nCPUs, int permutations, uint64_t last_seed_used);
+               int nCPUs, int permutations,
+               const std::string& _permutation_method,
+               uint64_t last_seed_used);
 
     virtual ~MultiGeary();
 
     virtual void ComputeLoalSA() ;
 
     virtual void PermLocalSA(int cnt, int perm, const std::vector<int> &permNeighbors, std::vector<double>& permutedSA);
+
+    virtual void PermLocalSA(int cnt, int perm, int numNeighbors, const int* permNeighbors, std::vector<double>& permutedSA){}
 
     virtual uint64_t CountLargerSA(int cnt, const std::vector<double>& permutedSA);
 

--- a/src/libgeoda_src/sa/MultiJoinCount.cpp
+++ b/src/libgeoda_src/sa/MultiJoinCount.cpp
@@ -13,8 +13,8 @@
 MultiJoinCount::MultiJoinCount(int num_obs, GeoDaWeight *w,
                            const std::vector<std::vector<double> > &_data,
                            const std::vector<std::vector<bool> > &_undefs,
-                           double significance_cutoff, int _nCPUs, int _perm, uint64_t _last_seed)
-        : LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _last_seed),
+                           double significance_cutoff, int _nCPUs, int _perm, const std::string& _permutation_method, uint64_t _last_seed)
+        : LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _permutation_method, _last_seed),
           CLUSTER_NOT_SIG(0),
           CLUSTER_SIG(1),
           CLUSTER_UNDEFINED(2),

--- a/src/libgeoda_src/sa/MultiJoinCount.h
+++ b/src/libgeoda_src/sa/MultiJoinCount.h
@@ -15,10 +15,12 @@ class MultiJoinCount : public LISA {
 
 public:
     MultiJoinCount(int num_obs, GeoDaWeight* w,
-                 const std::vector<std::vector<double> >& data,
-                 const std::vector<std::vector<bool> >& undefs,
-                 double significance_cutoff,
-                 int nCPUs, int permutations, uint64_t last_seed_used);
+                   const std::vector<std::vector<double> >& data,
+                   const std::vector<std::vector<bool> >& undefs,
+                   double significance_cutoff,
+                   int nCPUs, int permutations,
+                   const std::string& _permutation_method,
+                   uint64_t last_seed_used);
 
     virtual ~MultiJoinCount();
 
@@ -27,6 +29,8 @@ public:
     virtual void ComputeLoalSA() ;
 
     virtual void PermLocalSA(int cnt, int perm, const std::vector<int> &permNeighbors, std::vector<double>& permutedSA);
+
+    virtual void PermLocalSA(int cnt, int perm, int numNeighbors, const int* permNeighbors, std::vector<double>& permutedSA){}
 
     virtual uint64_t CountLargerSA(int cnt, const std::vector<double>& permutedSA);
 

--- a/src/libgeoda_src/sa/UniG.cpp
+++ b/src/libgeoda_src/sa/UniG.cpp
@@ -18,8 +18,8 @@ UniG::UniG(int num_obs,
            const std::vector<double> &_data,
            const std::vector<bool> &_undefs,
            double significance_cutoff,
-           int _nCPUs, int _perm, uint64_t _last_seed)
-: LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _last_seed),
+           int _nCPUs, int _perm, const std::string& _permutation_method, uint64_t _last_seed)
+: LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _permutation_method, _last_seed),
           CLUSTER_NOT_SIG(0),
           CLUSTER_HIGHHIGH(1),
           CLUSTER_LOWLOW(2),

--- a/src/libgeoda_src/sa/UniG.h
+++ b/src/libgeoda_src/sa/UniG.h
@@ -25,7 +25,9 @@ public:
          const std::vector<double>& data,
          const std::vector<bool>& undefs,
          double significance_cutoff,
-         int nCPUs, int permutations, uint64_t last_seed_used);
+         int nCPUs, int permutations,
+         const std::string& _permutation_method,
+         uint64_t last_seed_used);
 
 
     virtual ~UniG();
@@ -33,6 +35,8 @@ public:
     virtual void ComputeLoalSA() ;
 
     virtual void PermLocalSA(int cnt, int perm, const std::vector<int> &permNeighbors, std::vector<double>& permutedSA);
+
+    virtual void PermLocalSA(int cnt, int perm, int numNeighbors, const int* permNeighbors, std::vector<double>& permutedSA){}
 
     virtual uint64_t CountLargerSA(int cnt, const std::vector<double>& permutedSA);
 

--- a/src/libgeoda_src/sa/UniGeary.cpp
+++ b/src/libgeoda_src/sa/UniGeary.cpp
@@ -7,8 +7,8 @@
 #include "UniGeary.h"
 
 UniGeary::UniGeary(int num_obs, GeoDaWeight *w, const std::vector<double> &_data, const std::vector<bool> &_undefs,
-                   double significance_cutoff, int _nCPUs, int _perm, uint64_t _last_seed)
-: LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _last_seed),
+                   double significance_cutoff, int _nCPUs, int _perm, const std::string& _permutation_method, uint64_t _last_seed)
+: LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _permutation_method, _last_seed),
   CLUSTER_NOT_SIG(0),
   CLUSTER_HIGHHIGH(1),
   CLUSTER_LOWLOW(2),

--- a/src/libgeoda_src/sa/UniGeary.h
+++ b/src/libgeoda_src/sa/UniGeary.h
@@ -23,7 +23,9 @@ public:
              const std::vector<double>& data,
              const std::vector<bool>& undefs,
              double significance_cutoff,
-             int nCPUs, int permutations, uint64_t last_seed_used);
+             int nCPUs, int permutations,
+             const std::string& _permutation_method,
+             uint64_t last_seed_used);
 
 
     virtual ~UniGeary();
@@ -31,6 +33,8 @@ public:
     virtual void ComputeLoalSA() ;
 
     virtual void PermLocalSA(int cnt, int perm, const std::vector<int> &permNeighbors, std::vector<double>& permutedSA);
+
+    virtual void PermLocalSA(int cnt, int perm, int numNeighbors, const int* permNeighbors, std::vector<double>& permutedSA){}
 
     virtual uint64_t CountLargerSA(int cnt, const std::vector<double>& permutedSA);
 

--- a/src/libgeoda_src/sa/UniGstar.cpp
+++ b/src/libgeoda_src/sa/UniGstar.cpp
@@ -18,8 +18,8 @@ UniGstar::UniGstar(int num_obs,
            const std::vector<double> &_data,
            const std::vector<bool> &_undefs,
            double significance_cutoff,
-           int _nCPUs, int _perm, uint64_t _last_seed)
-        : LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _last_seed),
+           int _nCPUs, int _perm, const std::string& _permutation_method, uint64_t _last_seed)
+        : LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _permutation_method, _last_seed),
           CLUSTER_NOT_SIG(0),
           CLUSTER_HIGHHIGH(1),
           CLUSTER_LOWLOW(2),

--- a/src/libgeoda_src/sa/UniGstar.h
+++ b/src/libgeoda_src/sa/UniGstar.h
@@ -25,13 +25,17 @@ public:
              const std::vector<double>& data,
              const std::vector<bool>& undefs,
              double significance_cutoff,
-             int nCPUs, int permutations, uint64_t last_seed_used);
+             int nCPUs, int permutations,
+             const std::string& _permutation_method,
+             uint64_t last_seed_used);
 
     virtual ~UniGstar();
 
     virtual void ComputeLoalSA() ;
 
     virtual void PermLocalSA(int cnt, int perm, const std::vector<int> &permNeighbors, std::vector<double>& permutedSA);
+
+    virtual void PermLocalSA(int cnt, int perm, int numNeighbors, const int* permNeighbors, std::vector<double>& permutedSA){}
 
     virtual uint64_t CountLargerSA(int cnt, const std::vector<double>& permutedSA);
 

--- a/src/libgeoda_src/sa/UniJoinCount.cpp
+++ b/src/libgeoda_src/sa/UniJoinCount.cpp
@@ -15,8 +15,8 @@ UniJoinCount::UniJoinCount(int num_obs, GeoDaWeight *w,
         const std::vector<double> &_data,
         const std::vector<bool> &_undefs,
         double significance_cutoff,
-        int _nCPUs, int _perm, uint64_t _last_seed)
-: LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _last_seed),
+        int _nCPUs, int _perm, const std::string& _permutation_method, uint64_t _last_seed)
+: LISA(num_obs, w, _undefs, significance_cutoff, _nCPUs, _perm, _permutation_method, _last_seed),
   CLUSTER_NOT_SIG(0),
   CLUSTER_SIG(1),
   CLUSTER_UNDEFINED(2),

--- a/src/libgeoda_src/sa/UniJoinCount.h
+++ b/src/libgeoda_src/sa/UniJoinCount.h
@@ -17,10 +17,11 @@ class UniJoinCount : public LISA {
 
 public:
     UniJoinCount(int num_obs, GeoDaWeight* w,
-             const std::vector<double>& data,
-             const std::vector<bool>& undefs,
-             double significance_cutoff,
-                 int nCPUs, int permutations, uint64_t last_seed_used);
+                 const std::vector<double>& data,
+                 const std::vector<bool>& undefs,
+                 double significance_cutoff,
+                 int nCPUs, int permutations,
+                 const std::string& _permutation_method, uint64_t last_seed_used);
 
     virtual ~UniJoinCount();
 
@@ -29,6 +30,8 @@ public:
     virtual void ComputeLoalSA() ;
 
     virtual void PermLocalSA(int cnt, int perm, const std::vector<int> &permNeighbors, std::vector<double>& permutedSA);
+
+    virtual void PermLocalSA(int cnt, int perm, int numNeighbors, const int* permNeighbors, std::vector<double>& permutedSA){}
 
     virtual uint64_t CountLargerSA(int cnt, const std::vector<double>& permutedSA);
 

--- a/src/libgeoda_src/sa/UniLocalMoran.h
+++ b/src/libgeoda_src/sa/UniLocalMoran.h
@@ -27,13 +27,17 @@ public:
             const std::vector<double>& data,
             const std::vector<bool>& undefs,
             double significance_cutoff,
-            int nCPUs, int permutations, uint64_t last_seed_used);
+            int nCPUs, int permutations,
+            const std::string& _permutation_method,
+            uint64_t last_seed_used);
 
     virtual ~UniLocalMoran();
 
     virtual void ComputeLoalSA() ;
 
     virtual void PermLocalSA(int cnt, int perm, const std::vector<int> &permNeighbors, std::vector<double>& permutedSA);
+
+    virtual void PermLocalSA(int cnt, int perm, int numNeighbors, const int* permNeighbors, std::vector<double>& permutedSA);
 
     virtual uint64_t CountLargerSA(int cnt, const std::vector<double>& permutedSA);
 

--- a/src/rcpp_lisa.cpp
+++ b/src/rcpp_lisa.cpp
@@ -126,7 +126,7 @@ double p_LISA__GetFDR(SEXP xp, double pval)
 }
 
 //  [[Rcpp::export]]
-SEXP p_localmoran(SEXP xp_w, NumericVector data, int permutations, double significance_cutoff, int cpu_threads, int seed)
+SEXP p_localmoran(SEXP xp_w, NumericVector data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed)
 {
   // grab the object as a XPtr (smart pointer) to GeoDaWeight
   Rcpp::XPtr<GeoDaWeight> ptr(xp_w);
@@ -141,7 +141,7 @@ SEXP p_localmoran(SEXP xp_w, NumericVector data, int permutations, double signif
     undefs[i] = data.is_na(i);
   }
 
-  LISA* lisa = gda_localmoran(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, seed);
+  LISA* lisa = gda_localmoran(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, permutation_method, seed);
 
   Rcpp::XPtr<LISA> lisa_ptr(lisa, true);
   return lisa_ptr;
@@ -169,7 +169,7 @@ DataFrame p_eb_rate(NumericVector& event_data, NumericVector& base_data)
 }
 
 //  [[Rcpp::export]]
-SEXP p_localmoran_eb(SEXP xp_w, NumericVector& event_data, NumericVector& base_data, int permutations, double significance_cutoff, int cpu_threads, int seed)
+SEXP p_localmoran_eb(SEXP xp_w, NumericVector& event_data, NumericVector& base_data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed)
 {
   // grab the object as a XPtr (smart pointer) to GeoDaWeight
   Rcpp::XPtr<GeoDaWeight> ptr(xp_w);
@@ -178,14 +178,14 @@ SEXP p_localmoran_eb(SEXP xp_w, NumericVector& event_data, NumericVector& base_d
   std::vector<double> raw_event_data =  as<std::vector<double> >(event_data);
   std::vector<double> raw_base_data =  as<std::vector<double> >(base_data);
 
-  LISA* lisa = gda_localmoran_eb(w, raw_event_data, raw_base_data, significance_cutoff, cpu_threads, permutations, seed);
+  LISA* lisa = gda_localmoran_eb(w, raw_event_data, raw_base_data, significance_cutoff, cpu_threads, permutations, permutation_method, seed);
 
   Rcpp::XPtr<LISA> lisa_ptr(lisa, true);
   return lisa_ptr;
 }
 
 //  [[Rcpp::export]]
-SEXP p_localgeary(SEXP xp_w, NumericVector& data, int permutations, double significance_cutoff, int cpu_threads, int seed)
+SEXP p_localgeary(SEXP xp_w, NumericVector& data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed)
 {
   // grab the object as a XPtr (smart pointer) to GeoDaWeight
   Rcpp::XPtr<GeoDaWeight> ptr(xp_w);
@@ -199,14 +199,14 @@ SEXP p_localgeary(SEXP xp_w, NumericVector& data, int permutations, double signi
     undefs[i] = data.is_na(i);
   }
 
-  LISA* lisa = gda_localgeary(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, seed);
+  LISA* lisa = gda_localgeary(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, permutation_method, seed);
 
   Rcpp::XPtr<LISA> lisa_ptr(lisa, true);
   return lisa_ptr;
 }
 
 //  [[Rcpp::export]]
-SEXP p_localmultigeary(SEXP xp_w, Rcpp::List& data, int n_vars, int permutations, double significance_cutoff, int cpu_threads, int seed)
+SEXP p_localmultigeary(SEXP xp_w, Rcpp::List& data, int n_vars, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed)
 {
   // grab the object as a XPtr (smart pointer) to GeoDaWeight
   Rcpp::XPtr<GeoDaWeight> ptr(xp_w);
@@ -227,7 +227,7 @@ SEXP p_localmultigeary(SEXP xp_w, Rcpp::List& data, int n_vars, int permutations
     }
   }
 
-  LISA* lisa = gda_localmultigeary(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, seed);
+  LISA* lisa = gda_localmultigeary(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, permutation_method, seed);
 
   Rcpp::XPtr<LISA> lisa_ptr(lisa, true);
   return lisa_ptr;
@@ -235,7 +235,7 @@ SEXP p_localmultigeary(SEXP xp_w, Rcpp::List& data, int n_vars, int permutations
 
 
 //  [[Rcpp::export]]
-SEXP p_localg(SEXP xp_w, NumericVector& data, int permutations, double significance_cutoff, int cpu_threads, int seed)
+SEXP p_localg(SEXP xp_w, NumericVector& data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed)
 {
   // grab the object as a XPtr (smart pointer) to GeoDaWeight
   Rcpp::XPtr<GeoDaWeight> ptr(xp_w);
@@ -250,14 +250,14 @@ SEXP p_localg(SEXP xp_w, NumericVector& data, int permutations, double significa
     undefs[i] = data.is_na(i);
   }
 
-  LISA* lisa = gda_localg(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, seed);
+  LISA* lisa = gda_localg(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, permutation_method, seed);
 
   Rcpp::XPtr<LISA> lisa_ptr(lisa, true);
   return lisa_ptr;
 }
 
 //  [[Rcpp::export]]
-SEXP p_localgstar(SEXP xp_w, NumericVector& data, int permutations, double significance_cutoff, int cpu_threads, int seed)
+SEXP p_localgstar(SEXP xp_w, NumericVector& data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed)
 {
   // grab the object as a XPtr (smart pointer) to GeoDaWeight
   Rcpp::XPtr<GeoDaWeight> ptr(xp_w);
@@ -272,14 +272,14 @@ SEXP p_localgstar(SEXP xp_w, NumericVector& data, int permutations, double signi
     undefs[i] = data.is_na(i);
   }
 
-  LISA* lisa = gda_localgstar(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, seed);
+  LISA* lisa = gda_localgstar(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, permutation_method, seed);
 
   Rcpp::XPtr<LISA> lisa_ptr(lisa, true);
   return lisa_ptr;
 }
 
 //  [[Rcpp::export]]
-SEXP p_localjoincount(SEXP xp_w, NumericVector& data, int permutations, double significance_cutoff, int cpu_threads, int seed)
+SEXP p_localjoincount(SEXP xp_w, NumericVector& data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed)
 {
   // grab the object as a XPtr (smart pointer) to GeoDaWeight
   Rcpp::XPtr<GeoDaWeight> ptr(xp_w);
@@ -294,14 +294,14 @@ SEXP p_localjoincount(SEXP xp_w, NumericVector& data, int permutations, double s
     undefs[i] = data.is_na(i);
   }
 
-  LISA* lisa = gda_localjoincount(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, seed);
+  LISA* lisa = gda_localjoincount(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, permutation_method, seed);
 
   Rcpp::XPtr<LISA> lisa_ptr(lisa, true);
   return lisa_ptr;
 }
 
 //  [[Rcpp::export]]
-SEXP p_localmultijoincount(SEXP xp_w, Rcpp::List& data, int n_vars, int permutations, double significance_cutoff, int cpu_threads, int seed)
+SEXP p_localmultijoincount(SEXP xp_w, Rcpp::List& data, int n_vars, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed)
 {
   // grab the object as a XPtr (smart pointer) to GeoDaWeight
   Rcpp::XPtr<GeoDaWeight> ptr(xp_w);
@@ -322,14 +322,14 @@ SEXP p_localmultijoincount(SEXP xp_w, Rcpp::List& data, int n_vars, int permutat
     }
   }
 
-  LISA* lisa = gda_localmultijoincount(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, seed);
+  LISA* lisa = gda_localmultijoincount(w, raw_data, undefs, significance_cutoff, cpu_threads, permutations, permutation_method, seed);
 
   Rcpp::XPtr<LISA> lisa_ptr(lisa, true);
   return lisa_ptr;
 }
 
 //  [[Rcpp::export]]
-SEXP p_quantilelisa(SEXP xp_w, int k, int quantile, NumericVector& data, int permutations, double significance_cutoff, int cpu_threads, int seed)
+SEXP p_quantilelisa(SEXP xp_w, int k, int quantile, NumericVector& data, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed)
 {
   // grab the object as a XPtr (smart pointer) to GeoDaWeight
   Rcpp::XPtr<GeoDaWeight> ptr(xp_w);
@@ -344,14 +344,14 @@ SEXP p_quantilelisa(SEXP xp_w, int k, int quantile, NumericVector& data, int per
     undefs[i] = data.is_na(i);
   }
 
-  LISA* lisa = gda_quantilelisa(w, k, quantile, raw_data, undefs, significance_cutoff, cpu_threads, permutations, seed);
+  LISA* lisa = gda_quantilelisa(w, k, quantile, raw_data, undefs, significance_cutoff, cpu_threads, permutations, permutation_method, seed);
 
   Rcpp::XPtr<LISA> lisa_ptr(lisa, true);
   return lisa_ptr;
 }
 
 //  [[Rcpp::export]]
-SEXP p_multiquantilelisa(SEXP xp_w, NumericVector& k_s, NumericVector& q_s, Rcpp::List& data_s, int permutations, double significance_cutoff, int cpu_threads, int seed)
+SEXP p_multiquantilelisa(SEXP xp_w, NumericVector& k_s, NumericVector& q_s, Rcpp::List& data_s, int permutations, std::string permutation_method, double significance_cutoff, int cpu_threads, int seed)
 {
   // grab the object as a XPtr (smart pointer) to GeoDaWeight
   Rcpp::XPtr<GeoDaWeight> ptr(xp_w);
@@ -375,7 +375,7 @@ SEXP p_multiquantilelisa(SEXP xp_w, NumericVector& k_s, NumericVector& q_s, Rcpp
     }
   }
 
-  LISA* lisa = gda_multiquantilelisa(w, ks, qs, raw_data_s, undefs_s, significance_cutoff, cpu_threads, permutations, seed);
+  LISA* lisa = gda_multiquantilelisa(w, ks, qs, raw_data_s, undefs_s, significance_cutoff, cpu_threads, permutations, permutation_method, seed);
 
   Rcpp::XPtr<LISA> lisa_ptr(lisa, true);
   return lisa_ptr;


### PR DESCRIPTION
e.g. 
```R
nat <- st_read("./data/natregimes.shp")
w <- queen_weights(nat)
lm1 <- local_moran(w, nat["HR70"], permutations = 9999, ppermutation_method = "lookup-table")
lm2 <- local_moran(w, nat["HR70"], permutations = 9999)
plot(lm1$p_vals, lm2$p_vals)

system.time(lm2 <- local_moran(w, nat["HR70"], permutations = 9999))
system.time(lm1 <- local_moran(w, nat["HR70"], permutations = 9999, permutation_method = "lookup-table"))
```

0.076  vs 0.906  seconds

![image](https://user-images.githubusercontent.com/2423887/107845511-3ade4080-6d99-11eb-8284-ff6fef226516.png)
